### PR TITLE
Depth last variant and empty spots

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { optimize } from './optimize';
 // The entire heuristic for determining the auto layout of a graph
 export function digl(config: Config): Digl {
   function positions(start: string, nodes: Node[], edges: Edge[]): Layout {
-    const _ranks = optimize(getRanks(start, edges), edges);
+    const _ranks = optimize(getRanks(start, edges, config.depthLast), edges)
     return positioning(config, nodes, _ranks);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,31 @@ import positioning from './positioning';
 import { Config, Edge, Node, Layout, Rank, Digl } from './types';
 import { optimize } from './optimize';
 
+const addEmptySpots = (ranks: Rank[], edges: Edge[]): Rank[] => {
+  ranks.forEach((rank, i) => {
+    rank.forEach((node, y) => {
+      const edgesOut = edges.filter((edge) => edge.source === node)
+      edgesOut.forEach((edge) => {
+        const rankOfTarget = ranks.findIndex((rank) =>
+          rank.includes(edge.target)
+        )
+        if (rankOfTarget > i + 1) {
+          for (let z = i + 1; z < rankOfTarget; z++) {
+            ranks[z] = [...ranks[z].slice(0, y), null, ...ranks[z].slice(y)]
+          }
+        }
+      })
+    })
+  })
+  return ranks
+}
+
 // The entire heuristic for determining the auto layout of a graph
 export function digl(config: Config): Digl {
   function positions(start: string, nodes: Node[], edges: Edge[]): Layout {
     const _ranks = optimize(getRanks(start, edges, config.depthLast), edges)
-    return positioning(config, nodes, _ranks);
+    const ranksWithEmptySpots = addEmptySpots(_ranks, edges)
+    return positioning(config, nodes, ranksWithEmptySpots)
   }
 
   function ranks(start: string, edges: Edge[]): Rank[] {

--- a/src/positioning.ts
+++ b/src/positioning.ts
@@ -20,7 +20,7 @@ export default function positioning(
 
     r.forEach((nodeId, nIndex) => {
       const _node: Node = nodes.find((n) => n.id == nodeId) as Node;
-
+      if (!_node) return
       const x = _h ? xStart : xStart + 2 * config.width * nIndex;
       const y = _h ? yStart + 2 * config.height * nIndex : yStart;
       _nodes.push({ ..._node, x, y });

--- a/src/ranks.ts
+++ b/src/ranks.ts
@@ -56,7 +56,7 @@ function getInitialRanksWithDupes(nodes: string[], edges: Edge[]) {
 export default function initial(
   nodeId: string,
   edges: Edge[],
-  depthLast = true
+  depthLast = false
 ): Rank[] {
   const visited: V = {};
   const _paths = getPaths(nodeId, edges);
@@ -77,7 +77,7 @@ export default function initial(
   const chosenInitial = depthLast ? _initialDepthLast : _initial
 
   _paths.forEach((p) => {
-    chosenInitial.forEach((rank: string[], index: number) => {
+    chosenInitial.forEach((rank: (string| null)[], index: number) => {
       const nodes = p.filter((n) => rank.includes(n) && !visited[n]);
       if (nodes && nodes.length > 0) {
         nodes.forEach((n) => (visited[n] = true));

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type Config = {
   width: number;
   height: number;
   orientation: 'horizontal' | 'vertical';
+  depthLast?: boolean
 };
 
 export type Layout = PositionedNode[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type Config = {
 };
 
 export type Layout = PositionedNode[];
-export type Rank = string[];
+export type Rank = (string | null)[];
 export type Digl = {
   positions(start: string, nodes: Node[], edges: Edge[]): Layout;
   ranks(start: string, edges: Edge[]): Rank[];


### PR DESCRIPTION
Add option to change the algorithm to rank according the the longest path to the node instead of the shortest. This variant results in path always going down (I hope) and never to the same level or up.
The second change is to add empty spots so that path going to more than 1 rank down do not cross through nodes in the intermediate ranks...
One issue I face and haven't solve is that the algo change to get the longest path will make an infinite loop if there is a loop in the graph...